### PR TITLE
Fix menu registration compatibility with Zotero 8

### DIFF
--- a/patches/README.md
+++ b/patches/README.md
@@ -12,10 +12,10 @@ during plugin startup are silently discarded, so Zotero IF's right-click
 The patched `menuPopup.js` adds a new code path that uses Zotero 8's
 `Zotero.MenuManager.registerMenu()` API when it is available:
 
-- **`main/library/item`** — right-click a selected item to see
-  "更新 IF / 分区 [Zotero IF]".
-- **`main/menubar/tools`** — the same action also appears in the top-level
-  Tools menu.
+- **`main/library/item`** — right-click a selected item to see the localized
+  "Update IF(s)" action.
+- **`main/menubar/tools`** — the same localized action also appears in the
+  top-level Tools menu.
 
 If `Zotero.MenuManager` is not present (Zotero 7 and earlier), the plugin
 falls back to the original direct-DOM-insertion logic, so no existing behavior
@@ -33,10 +33,10 @@ is broken.
 1. Unzip the released `.xpi`.
 2. Replace `chrome/content/scripts/menuPopup.js` with the file in this
    directory.
-3. In `manifest.json`, change `strict_max_version` from `"7.0.*"` to `"999.*"`.
+3. In `manifest.json`, change `strict_max_version` from `"10.9.*"` to `"999.*"`.
 4. Re-zip and install.
 
 ## Tested on
 
-- Zotero 8 (Windows 11)
+- Zotero 8.0.4 (Windows)
 - Plugin version 1.6.0 (base) → 1.6.0.2 (patched)

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,0 +1,42 @@
+# Zotero 8 Menu Compatibility Patch
+
+## Problem
+
+Zotero 8 rebuilds the library item context menu (`zotero-itemmenu`) before each
+opening. Menu items appended directly via `document.getElementById('zotero-itemmenu').appendChild()`
+during plugin startup are silently discarded, so Zotero IF's right-click
+"Update IF(s)" action never appears.
+
+## Solution
+
+The patched `menuPopup.js` adds a new code path that uses Zotero 8's
+`Zotero.MenuManager.registerMenu()` API when it is available:
+
+- **`main/library/item`** — right-click a selected item to see
+  "更新 IF / 分区 [Zotero IF]".
+- **`main/menubar/tools`** — the same action also appears in the top-level
+  Tools menu.
+
+If `Zotero.MenuManager` is not present (Zotero 7 and earlier), the plugin
+falls back to the original direct-DOM-insertion logic, so no existing behavior
+is broken.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `menuPopup.js` | Drop-in replacement for `chrome/content/scripts/menuPopup.js` inside the XPI |
+| `manifest-changes.json` | Describes the one-field change needed in `manifest.json` (`strict_max_version` → `999.*`) |
+
+## How to apply
+
+1. Unzip the released `.xpi`.
+2. Replace `chrome/content/scripts/menuPopup.js` with the file in this
+   directory.
+3. In `manifest.json`, change `strict_max_version` from `"7.0.*"` to `"999.*"`.
+4. Re-zip and install.
+
+## Tested on
+
+- Zotero 8 (Windows 11)
+- Plugin version 1.6.0 (base) → 1.6.0.2 (patched)

--- a/patches/manifest-changes.json
+++ b/patches/manifest-changes.json
@@ -1,0 +1,12 @@
+{
+  "description": "Changes to manifest.json for Zotero 8 compatibility",
+  "changes": [
+    {
+      "field": "applications.zotero.strict_max_version",
+      "original": "7.0.*",
+      "patched": "999.*",
+      "reason": "Allow installation on Zotero 8 and future versions"
+    }
+  ],
+  "note": "The version field may be updated by the maintainer as appropriate."
+}

--- a/patches/manifest-changes.json
+++ b/patches/manifest-changes.json
@@ -3,7 +3,7 @@
   "changes": [
     {
       "field": "applications.zotero.strict_max_version",
-      "original": "7.0.*",
+      "original": "10.9.*",
       "patched": "999.*",
       "reason": "Allow installation on Zotero 8 and future versions"
     }

--- a/patches/menuPopup.js
+++ b/patches/menuPopup.js
@@ -55,10 +55,6 @@ ZoteroIF_MenuPopup = {
         };
 
         let configureMenuItem = (event, context) => {
-            let menuElem = context && context.menuElem;
-            if (menuElem) {
-                menuElem.setAttribute('label', '更新 IF / 分区 [Zotero IF]');
-            }
             let enabled = this._hasSelectedRegularItems(context);
             if (context && context.setEnabled) {
                 context.setEnabled(enabled);
@@ -76,6 +72,7 @@ ZoteroIF_MenuPopup = {
                 menus: [
                     {
                         menuType: 'menuitem',
+                        l10nID: 'zotero-zoteroif-update-if',
                         icon: 'chrome://zoteroif/content/icons/favicon.png',
                         onShowing: configureMenuItem,
                         onCommand: updateSelectedItemsIF
@@ -89,6 +86,7 @@ ZoteroIF_MenuPopup = {
                 menus: [
                     {
                         menuType: 'menuitem',
+                        l10nID: 'zotero-zoteroif-update-if',
                         icon: 'chrome://zoteroif/content/icons/favicon.png',
                         enableForTabTypes: ['library'],
                         onShowing: configureMenuItem,

--- a/patches/menuPopup.js
+++ b/patches/menuPopup.js
@@ -1,0 +1,137 @@
+ZoteroIF_MenuPopup = {
+    _store_added_elements: [],
+    _registeredMenuIDs: [],
+
+    _getWindow() {
+        var enumerator = Services.wm.getEnumerator("navigator:browser");
+        while (enumerator.hasMoreElements()) {
+            let win = enumerator.getNext();
+            if (!win.ZoteroPane) continue;
+            return win;
+        }
+    },
+
+    init() {
+        if (this._registerWithMenuManager()) {
+            return;
+        }
+
+        let win = this._getWindow();
+        let doc = win.document;
+
+        // Menu separator
+        let menuseparator = doc.createXULElement('menuseparator');
+
+        // Menu item
+        let updateIFs_item = doc.createXULElement('menuitem');
+        updateIFs_item.id = 'zoteroif-menuitem-updateIFs';
+        updateIFs_item.setAttribute('data-l10n-id', 'zotero-zoteroif-update-if');
+        updateIFs_item.addEventListener('command', () => {
+            Zotero.ZoteroIF.updateSelectedItemsIF();
+        });
+
+        let zotero_itemmenu = doc.getElementById('zotero-itemmenu');
+        zotero_itemmenu.appendChild(menuseparator);
+        zotero_itemmenu.appendChild(updateIFs_item);
+
+        this._store_added_elements.push(menuseparator, updateIFs_item);
+
+        // Enable localization
+        win.MozXULElement.insertFTLIfNeeded('zoteroif_preferences.ftl');
+    },
+
+    _registerWithMenuManager() {
+        if (!Zotero.MenuManager || !Zotero.MenuManager.registerMenu) {
+            return false;
+        }
+
+        let win = this._getWindow();
+        if (win && win.MozXULElement) {
+            win.MozXULElement.insertFTLIfNeeded('zoteroif_preferences.ftl');
+        }
+
+        let updateSelectedItemsIF = () => {
+            Zotero.ZoteroIF.updateSelectedItemsIF();
+        };
+
+        let configureMenuItem = (event, context) => {
+            let menuElem = context && context.menuElem;
+            if (menuElem) {
+                menuElem.setAttribute('label', '更新 IF / 分区 [Zotero IF]');
+            }
+            let enabled = this._hasSelectedRegularItems(context);
+            if (context && context.setEnabled) {
+                context.setEnabled(enabled);
+            }
+            if (context && context.setVisible) {
+                context.setVisible(enabled);
+            }
+        };
+
+        let menus = [
+            {
+                menuID: 'zoteroif-update-library-item',
+                pluginID: 'zoteroif@qnscholar',
+                target: 'main/library/item',
+                menus: [
+                    {
+                        menuType: 'menuitem',
+                        icon: 'chrome://zoteroif/content/icons/favicon.png',
+                        onShowing: configureMenuItem,
+                        onCommand: updateSelectedItemsIF
+                    }
+                ]
+            },
+            {
+                menuID: 'zoteroif-update-tools-menu',
+                pluginID: 'zoteroif@qnscholar',
+                target: 'main/menubar/tools',
+                menus: [
+                    {
+                        menuType: 'menuitem',
+                        icon: 'chrome://zoteroif/content/icons/favicon.png',
+                        enableForTabTypes: ['library'],
+                        onShowing: configureMenuItem,
+                        onCommand: updateSelectedItemsIF
+                    }
+                ]
+            }
+        ];
+
+        for (let menu of menus) {
+            let registeredID = Zotero.MenuManager.registerMenu(menu);
+            if (registeredID) {
+                this._registeredMenuIDs.push(menu.menuID);
+            }
+        }
+
+        return this._registeredMenuIDs.length > 0;
+    },
+
+    _hasSelectedRegularItems(context) {
+        let items = context && context.items;
+        if (!items) {
+            let pane = Zotero.getActiveZoteroPane && Zotero.getActiveZoteroPane();
+            items = pane && pane.getSelectedItems ? pane.getSelectedItems() : [];
+        }
+        return items.some(item => item && item.isRegularItem && item.isRegularItem());
+    },
+
+    destroy() {
+        for (let menuID of this._registeredMenuIDs) {
+            Zotero.MenuManager.unregisterMenu(menuID);
+        }
+        this._registeredMenuIDs = [];
+
+        let win = this._getWindow();
+        let doc = win && win.document;
+        for (let element of this._store_added_elements)
+        {
+            if (element) element.remove();
+        }
+        let ftl = doc && doc.querySelector('[href="zoteroif_preferences.ftl"]');
+        if (ftl) {
+            ftl.remove();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Zotero 8 rebuilds library item context menus (`zotero-itemmenu`) before opening them, so menu items appended directly during plugin startup can be discarded.
- This patch provides a replacement `menuPopup.js` that registers menu actions through `Zotero.MenuManager.registerMenu()` when available, while preserving the existing direct DOM insertion fallback for older Zotero versions.
- It also documents the manifest compatibility change from `strict_max_version: "10.9.*"` to `"999.*"`.

## Changes

Since this repository does not contain the plugin source code, the patch is provided in a `patches/` directory:

| File | Description |
|------|-------------|
| `patches/menuPopup.js` | Drop-in replacement for `chrome/content/scripts/menuPopup.js` inside the XPI |
| `patches/manifest-changes.json` | Documents the `strict_max_version` change needed in `manifest.json` |
| `patches/README.md` | Explanation of the problem, solution, and how to apply |

## New entry points

- Right-click selected library items -> localized **Update IF(s)** action
- Top menu -> **Tools** -> localized **Update IF(s)** action

## Test plan

- [x] Verified against the Zotero IF v1.6.0 XPI layout
- [x] `node --check patches/menuPopup.js`
- [x] Installed an equivalent patched XPI in Zotero 8.0.4 on Windows and confirmed the extension is active, not user-disabled, and not app-disabled
- [ ] Maintainer to verify the UI entry points and older Zotero fallback path