### PR TITLE
Fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,4 +32,4 @@ Update IF for Zotero Items.
 
 ## 🌟 Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=qnscholar/zotero-if&type=Timeline)](https://star-history.com/#qnscholar/zotero-if&Timeline)
+[![Star History Chart](https://star-history.dera.page/svg?repos=qnscholar/zotero-if&type=Timeline)](https://star-history.dera.page/#qnscholar/zotero-if&Timeline)


### PR DESCRIPTION
The star history chart in the README is currently broken because of GitHub stargazer API restrictions. This change updates the chart to use a working alternative, so it renders correctly again.